### PR TITLE
OCSP: fixed use-after-free on error.

### DIFF
--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -1141,6 +1141,7 @@ ngx_http_uwsgi_create_request(ngx_http_request_t *r)
         r->upstream->request_bufs = cl;
     }
 
+    b->flush = 1;
     cl->next = NULL;
 
     return NGX_OK;


### PR DESCRIPTION
When validating second and further certificates, ssl callback could be called
twice to report the error.  After the first call client connection is
terminated and its memory is released.  Prior to the second call and in it
released connection memory is accessed.

Errors triggering this behavior:
- failure to create the request
- failure to start resolving OCSP responder name
- failure to start connecting to the OCSP responder

The fix is to rearrange the code to eliminate the second call.